### PR TITLE
Allow specifying custom suspicious URL fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Current implementation supports the followings:<br/>
 * Cross Site Scripting detection
 * Path Traversal detection
 * SQL Injection detection
+* Now, allows specifying custom suspiciousUrlFragments, to suite your needs. 
 
 Please note that this module will never be able to detect security threats with 100% precision. The goal of this project is to catch and report the very first 'obvious' attempts, if possible.
 
@@ -38,7 +39,13 @@ app.use(expressDefend.protect({
     logFile: 'suspicious.log',        // if specified, express-defend will log it's output here
     onMaxAttemptsReached: function(ipAddress, url){
         console.log('IP address ' + ipAddress + ' is considered to be malicious, URL: ' + url);
-    } 
+    },
+    suspiciousUrlFragments: [        // specify extra url fragments that should be blocked, extends the defaults.
+        {
+            category: 'Custom Path Traversal',
+            patterns: ['etc/passwd', 'etc/pwd']
+        }
+    ]
 }));
 ```
 

--- a/lib/express-defend.js
+++ b/lib/express-defend.js
@@ -100,6 +100,10 @@ module.exports = {
 			this.fs = require('fs');
 			this.fileAppender = this.fs.appendFile;
 		}
+		// allow passing in extra suspiciousUrlFragments as an array of strings to expand the default set
+		if (settings.suspiciousUrlFragments != undefined && Array.isArray(settings.suspiciousUrlFragments) && settings.suspiciousUrlFragments.length) {
+			this.suspiciousUrlFragments = this.suspiciousUrlFragments.concat(settings.suspiciousUrlFragments);
+		}
 	},
 
 	handleSuspiciousRequest: function(request, response, next, category, blacklistItem) {

--- a/spec/configuring-spec.js
+++ b/spec/configuring-spec.js
@@ -19,6 +19,13 @@ function getMaliciousRequest() {
 		connection: { remoteAddress: '127.0.0.1' }
 	};
 }
+function getMaliciousRequestCustom() {
+	return {
+		originalUrl: '/login.action',
+		headers: {},
+		connection: { remoteAddress: '127.0.0.1' }
+	};
+}
 
 function getNormalRequest() {
 	return { 
@@ -85,7 +92,24 @@ describe("Check configuration: ", function() {
     // Assert
 	expect(nextMockInvoked).toBe(true);
   });
+	it('should accept custom `suspiciousUrlFragments` to expand the default set', function () {
+		const customSuspiciousUrlFragments = [
+			{
+				category: 'Extra Fragments',
+				patterns: ['login.action']
+			}
+		];
+		// Arrange
+		var interceptor = expressDefend.protect({ consoleLogging: false, dropSuspiciousRequest: true, suspiciousUrlFragments: customSuspiciousUrlFragments, maxAttempts: 1 });
+		var request = getMaliciousRequestCustom();
 
+		// Act
+		interceptor(request, responseMock, nextMock);
+
+		// Assert
+		expect(nextMockInvoked).toBe(false);
+		expect(responseMock.statusCode).toBe(403);
+	});
   it('dropSuspiciousRequest = false, allowing after 2nd attempt even if maxAttempts is 1', function() {
 
   	// Arrange


### PR DESCRIPTION
Not sure if you're accepting PRs but I ran into a similar situation that I think [this issue ](https://github.com/akos-sereg/express-defend/issues/1) did. Now with this change that is possible. I know this hasn't been updated in a little while but I like it's simplicity I just wish I could specify my own patterns/fragments.

It supports pass along `suspiciousUrlFragments` when calling `protect`, using the same signature as the existing one an array containing `category: string` and `patterns: string[]`. These will get added on top of the existing default fragments.
```
suspiciousUrlFragments: [
        {
            category: 'Custom Fragments',
            patterns: ['etc/passwd', 'etc/pwd']
        }
]
```

I'll be using my fork for now, but figured I'd share this change in case you also saw some benefit in it. Cheers!